### PR TITLE
chore(deps): update server package-lock.json

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -158,6 +158,14 @@
         }
       }
     },
+    "node_modules/@cardano-sdk/core/node_modules/@dcspark/cardano-multiplatform-lib-nodejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@dcspark/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-3.1.2.tgz",
+      "integrity": "sha512-bfFI7ljC8El+yj4kG2G7GXcoHHhWJyJKonJ64H3Kcbns4+tHOTy525d1q/u4+hG+G42JPw4Zj5CFIBLv5GLMxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@cardano-sdk/dapp-connector": {
       "version": "0.13.26",
       "resolved": "https://registry.npmjs.org/@cardano-sdk/dapp-connector/-/dapp-connector-0.13.26.tgz",
@@ -209,6 +217,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@cardano-sdk/dapp-connector/node_modules/@dcspark/cardano-multiplatform-lib-nodejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@dcspark/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-3.1.2.tgz",
+      "integrity": "sha512-bfFI7ljC8El+yj4kG2G7GXcoHHhWJyJKonJ64H3Kcbns4+tHOTy525d1q/u4+hG+G42JPw4Zj5CFIBLv5GLMxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@cardano-sdk/input-selection": {
       "version": "0.14.28",
@@ -285,6 +301,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@dcspark/cardano-multiplatform-lib-nodejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@dcspark/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-3.1.2.tgz",
+      "integrity": "sha512-bfFI7ljC8El+yj4kG2G7GXcoHHhWJyJKonJ64H3Kcbns4+tHOTy525d1q/u4+hG+G42JPw4Zj5CFIBLv5GLMxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@cardano-sdk/util": {
       "version": "0.17.1",
@@ -1089,6 +1113,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@meshsdk/core-cst/node_modules/@dcspark/cardano-multiplatform-lib-nodejs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@dcspark/cardano-multiplatform-lib-nodejs/-/cardano-multiplatform-lib-nodejs-3.1.2.tgz",
+      "integrity": "sha512-bfFI7ljC8El+yj4kG2G7GXcoHHhWJyJKonJ64H3Kcbns4+tHOTy525d1q/u4+hG+G42JPw4Zj5CFIBLv5GLMxg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@meshsdk/provider": {
       "version": "1.9.0-beta.95",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update server lockfile to include resolved entries for optional peer `@dcspark/cardano-multiplatform-lib-nodejs@3.1.2` used by Cardano SDK packages, ensuring clean installs and avoiding peer warnings. No runtime code changes.

- **Dependencies**
  - Added `@dcspark/cardano-multiplatform-lib-nodejs@3.1.2` under `@cardano-sdk/core`, `@cardano-sdk/dapp-connector`, `@cardano-sdk/key-management`, and `@meshsdk/core-cst`.

<sup>Written for commit 66a034d93872e603f0ecb3ae3889be304f3d3034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/dns-frontend/pull/98?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

